### PR TITLE
Add front end envs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   agents-postgres:
@@ -50,6 +50,12 @@ services:
 
       # for users that want to use OpenAI models for narrative generation, after SQL is generated
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+
+      # front end non-admin config
+      - HIDE_SQL_TAB_FOR_NON_ADMIN=${HIDE_SQL_TAB_FOR_NON_ADMIN}
+      - HIDE_PREVIEW_TABS_FOR_NON_ADMIN=${HIDE_PREVIEW_TABS_FOR_NON_ADMIN}
+      - HIDDEN_CHARTS_FOR_NON_ADMIN=${HIDDEN_CHARTS_FOR_NON_ADMIN}
+      - HIDE_RAW_ANALYSIS_FOR_NON_ADMIN=${HIDE_RAW_ANALYSIS_FOR_NON_ADMIN}
     volumes:
       - agents-assets:/agents-assets/
     depends_on:


### PR DESCRIPTION
Related PRs: [DSH](https://github.com/defog-ai/defog-self-hosted/pull/279) and [UI](https://github.com/defog-ai/agents-ui-components/pull/76)

Adds four envs for controlling the UI for non admin users:

```
# set to "yes" if you want to hide the SQL/Code tab for non-admin users
HIDE_SQL_TAB_FOR_NON_ADMIN=

# set to "yes" if you want to hide the preview data and view data structure tabs for non-admin users
HIDE_PREVIEW_TABS_FOR_NON_ADMIN=

# comma separated list of chart names. all lowercase.
# can be: line, bar, scatter, histogram, boxplot
HIDDEN_CHARTS_FOR_NON_ADMIN=

# set to "yes" if you want to hide the raw analysis tab for non-admin users
HIDE_RAW_ANALYSIS_FOR_NON_ADMIN=
```

